### PR TITLE
Add Dev mode button

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -540,7 +540,8 @@ export default {
 			iOSCodeSigning,
 			androidKeystore,
 			customArgs,
-			enableLiveview
+			enableLiveview,
+			isDebugMode
 		} = this.toolbar.getState();
 		const logLevel = this.console.getLogLevel();
 		let message;
@@ -555,6 +556,10 @@ export default {
 
 			if (enableLiveview) {
 				args.push('--liveview');
+			}
+
+			if (isDebugMode) {
+				args.push('--debug-host localhost:8989');
 			}
 
 			const projectPath = (Project.isTitaniumApp) ? atom.project.getPaths()[0] : Project.pathForPlatform(platform);
@@ -649,7 +654,6 @@ export default {
 				}
 			}
 		}
-
 		const options = {
 			args: args,
 			log: (text) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -559,7 +559,7 @@ export default {
 			}
 
 			if (isDebugMode) {
-				args.push('--debug-host localhost:8989');
+				args.push('--debug-host', 'localhost:8989');
 			}
 
 			const projectPath = (Project.isTitaniumApp) ? atom.project.getPaths()[0] : Project.pathForPlatform(platform);

--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -85,6 +85,7 @@ export default class Toolbar {
 			targetName: null,
 			disableUI: true,
 			enableLiveview: atom.config.get('appcelerator-titanium.general.liveviewEnabled'),
+			isDebugMode: atom.config.get('appcelerator-titanium.general.isDebugMode'),
 			buildInProgress: false,
 			codeSigningAvailable: true,
 			showingCodeSigning: false,
@@ -327,6 +328,7 @@ export default class Toolbar {
 						</Select>
 
 						<Button icon="gear" title="Signing settings..." flat="true" disabled={this.state.disableUI || !this.state.codeSigningAvailable} click={this.expandButtonClicked.bind(this)} />
+						<Button icon="bug" title="Debug mode" flat="true" class={!this.state.isDebugMode ? 'disabled' : 'enabled'} click={this.debugModeButtonClick.bind(this)} />
 						<Octicon name={this.state.enableLiveview ? 'eye' : 'eye-closed'} title="Liveview" flat="true" disabled={this.shouldDisableLiveView()} click={this.liveViewButtonClicked.bind(this)} />
 					</div>
 
@@ -774,6 +776,17 @@ export default class Toolbar {
 		this.getState();
 
 		atom.config.set('appcelerator-titanium.general.liveviewEnabled', this.state.enableLiveview);
+		etch.update(this);
+	}
+
+	/**
+	 * Toggle debug mude
+	 */
+	debugModeButtonClick() {
+		this.state.isDebugMode = !this.state.isDebugMode;
+		this.getState();
+
+		atom.config.set('appcelerator-titanium.general.isDebugMode', this.state.isDebugMode);
 		etch.update(this);
 	}
 


### PR DESCRIPTION
![Screenshot_20210912_171343](https://user-images.githubusercontent.com/4334997/132993045-0ab89909-a2ca-4a47-bb55-b78a3a6c78d5.png)


Adding a button to toggle dev-mode. Instead of trying to open the devtools right away (like #80) it will just attach `--debug-host localhost:8989` and you have to open the devtools yourself.