### PR TITLE
fix: keep console closed at startup

### DIFF
--- a/lib/ui/console.jsx
+++ b/lib/ui/console.jsx
@@ -119,7 +119,7 @@ export default class Console {
 		this.subscriptions.add(
 			atom.workspace.onDidOpen(e => {
 				if (e.item === this) {
-					this.state.isHidden = false;
+					this.state.isHidden = true;
 				}
 			})
 		);

--- a/lib/ui/console.jsx
+++ b/lib/ui/console.jsx
@@ -188,7 +188,7 @@ export default class Console {
 	 * @returns {String}
 	 */
 	getTitle() {
-		return 'Appcelerator Console';
+		return 'Titanium console';
 	}
 
 	/**

--- a/lib/ui/console.jsx
+++ b/lib/ui/console.jsx
@@ -188,7 +188,7 @@ export default class Console {
 	 * @returns {String}
 	 */
 	getTitle() {
-		return 'Titanium console';
+		return 'Titanium SDK console';
 	}
 
 	/**


### PR DESCRIPTION
The console will automatically open some time when you open an old project. The `isHidden` state was automatically set to true, even if you don't use the console. 
It will still open when you press "play" or use the "toggle console"

Also setting the name to "Titanium console" instead of "Appcelerator Console".