### PR TITLE
fix(all) github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Install NPM dependencies
         run: npm ci
       - name: Lint
@@ -29,7 +29,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        atom_channel: [stable, beta]
+        atom_channel: [stable]
     steps:
       - uses: actions/checkout@v2
       - name: Cache
@@ -40,7 +40,7 @@ jobs:
             node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
 
-      - uses: UziTech/action-setup-atom@v1
+      - uses: UziTech/action-setup-atom@v3
         with:
           channel: ${{ matrix.atom_channel }}
       - name: Versions


### PR DESCRIPTION
Action is failing for the beta channel. Since there aren't any new betas of Atom I've removed that and updated some versions.


Btw: https://github.com/pulsar-edit/pulsar might be the successor of Atom. 