### PR TITLE
ci(release): install atom and apm first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
+      - uses: UziTech/action-setup-atom@v3
       - name: Install NPM dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
Missed this in the initial PR, release job [currently fails](https://github.com/tidev/atom-appcelerator-titanium/actions/runs/3236506162/jobs/5302406993) and this should fix it