### PR TITLE
ci: use pulsar action instead of atom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v3
@@ -29,7 +29,7 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Pulsar
         uses: pulsar-edit/action-pulsar-dependency@v3.2
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,24 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+  Test:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: Lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Pulsar
+        uses: pulsar-edit/action-pulsar-dependency@v3.2
+      - name: Install dependencies
+        run: npm ci
+      - name: Run the headless Pulsar Tests
+        uses: coactions/setup-xvfb@v1.0.1
+        with:
+          run: pulsar --test spec

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "commit": "git-cz",
     "lint": "eslint --ext .js,.jsx .",
     "release": "cross-env HUSKY=0 semantic-release",
-    "test": "apm --version && apm test",
+    "test": "ppm --version && ppm test",
     "postinstall": "husky install || exit 0",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"

--- a/spec/controllerAutoCompleteProvider-spec.js
+++ b/spec/controllerAutoCompleteProvider-spec.js
@@ -37,7 +37,7 @@ describe('Ti namespace suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -97,7 +97,7 @@ describe('Extended Ti suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -148,7 +148,7 @@ describe('Alloy namespace suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -208,7 +208,7 @@ describe('Extended Alloy suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});

--- a/spec/styleAutoCompleteProvider-spec.js
+++ b/spec/styleAutoCompleteProvider-spec.js
@@ -37,7 +37,7 @@ describe('Tag suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -93,7 +93,7 @@ describe('Property suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});

--- a/spec/viewAutoCompleteProvider-spec.js
+++ b/spec/viewAutoCompleteProvider-spec.js
@@ -37,7 +37,7 @@ describe('Tag suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 	});
 
@@ -95,7 +95,7 @@ describe('Attribute suggestions', function () {
 		await atomEnvironment.packages.triggerDeferredActivationHooks();
 		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
-		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
+		expect(atomEnvironment.packages.isPackageActive('titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});


### PR DESCRIPTION
Part of #654

Uses the setup-pulsar action to test against pulsar, this isn't as full featured as the setup-atom one but handily the features it's missing (mainly testing against different versions) doesn't matter as the entire project is in beta.

There's still some iffy bits around apm/ppm usage but what's there right now works on all 3 platforms.